### PR TITLE
New release 0.1.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+## [0.1.2] - 2023-01-29
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (b26fc3a)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mptcp-pm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
### Breaking changes
 - N/A

### New features
 - N/A

### Bug fixes
 - Use latest rust-netlink crates. (b26fc3a)
