### PR TITLE
Add `repository` metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Linux kernel MPTCP path manager netlink Library"
 keywords = ["network"]
 categories = ["network-programming", "os"]
 readme = "README.md"
+repository = "https://github.com/rust-netlink/mptcp-pm"
 
 [lib]
 name = "mptcp_pm"
@@ -21,12 +22,12 @@ smol_socket = ["netlink-proto/smol_socket", "async-std"]
 
 [dependencies]
 anyhow = "1.0.44"
-async-std = { version = "1.9.0", optional = true}
+async-std = { version = "1.9.0", optional = true }
 byteorder = "1.4.3"
 futures = "0.3.17"
 log = "0.4.14"
 thiserror = "1.0.29"
-tokio = { version = "1.0.1", features = ["rt"], optional = true}
+tokio = { version = "1.0.1", features = ["rt"], optional = true }
 genetlink = { default-features = false, version = "0.2.4" }
 netlink-packet-core = { version = "0.5.0" }
 netlink-packet-generic = { version = "0.3.2" }


### PR DESCRIPTION
This helps us find where the crate comes from.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>