### PR TITLE
New release 0.1.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.1.4] - 2025-08-28
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (024feb6)
+
 ## [0.1.3] - 2023-07-10
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mptcp-pm"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (024feb6)